### PR TITLE
Do not use "name" and "addr" for the query

### DIFF
--- a/scripts/mutt/address-query.sh
+++ b/scripts/mutt/address-query.sh
@@ -11,7 +11,7 @@ reset="$(tput sgr0)"
 regexp="s/^(.+\s)?<(.+)>$/${name}\1${reset}${brackets}<${reset}\2${brackets}>${reset}/"
 
 # execcute search
-jq -r '.[] | if .name != "" then "\(.name) <\(.address)>" else "<\(.address)>" end' \
+jq -r '.[] | "\(."name-addr")" ' \
       ${address_cache} | \
 sed -E ${regexp} | \
 fzf --query "$query" \

--- a/scripts/mutt/address-query.sh
+++ b/scripts/mutt/address-query.sh
@@ -10,7 +10,7 @@ reset="$(tput sgr0)"
 
 regexp="s/^(.+\s)?<(.+)>$/${name}\1${reset}${brackets}<${reset}\2${brackets}>${reset}/"
 
-# execcute search
+# execute search
 jq -r '.[] | "\(."name-addr")" ' \
       ${address_cache} | \
 sed -E ${regexp} | \


### PR DESCRIPTION
The JSON contains a "name-addr" field that we can use directly. This field also contains quoted entries for those names that contain commas, fixing #1 